### PR TITLE
fix: enforce collaborative event access boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,47 @@
 # Catching App
 
-Catching App is a web application designed to facilitate event planning and scheduling among friends. Users can create events, invite friends, and define available time slots for meetings, making it easier to coordinate schedules.
+> **Status:** completed collaborative Rails bootcamp project from 2021. It is preserved as team and learning evidence; its historical dependency graph has known security advisories and must not be exposed or deployed without a dedicated modernization.
 
-## Features
+Catching App coordinates a meeting across friends: a host creates an event, invites users, proposes time slots, guests submit their availability, and the host finalizes the agreed window from an authenticated dashboard.
 
-- User authentication with Devise
-- Create and manage events
-- Invite friends to events
-- Define and visualize available time slots
-- Responsive design with Bootstrap
-- User-friendly interface
+## What it demonstrates
 
-## Technologies Used
+- Devise authentication and user profiles.
+- Host-owned events and many-to-many guest invitations.
+- Per-user availability through event-scoped time slots.
+- Host-only final scheduling and invitee-only availability submission.
+- PostgreSQL associations, server-rendered Rails views, and Bootstrap-era frontend assets.
+- Dashboard aggregation of hosted and invited events.
 
-- Ruby on Rails
-- PostgreSQL
-- ActionCable for real-time features
-- Bootstrap for styling
-- JavaScript and jQuery for interactivity
-- Moment.js for date and time manipulation
+## Ownership and collaboration
 
-## Setup Instructions
+This was a three-person Le Wagon project with [Sedef Çakmak](https://github.com/sedcakmak) and [Ege Çakmak](https://github.com/Egecak). GitHub attributes substantial implementation work to Okan, including 11 merged pull requests and 47 of the newest 100 commits at the 2026-07-18 audit. [Okan's merged pull-request history](https://github.com/okturan/catching-app/pulls?q=is%3Apr+is%3Amerged+author%3Aokturan) is the durable attribution source; the repository is not presented as solo work.
 
-To set up the application locally, follow these steps:
+## Historical local setup
 
-1. **Clone the repository:**
+The lockfile targets Ruby 2.7.3 and Rails 6.0.4 with PostgreSQL. This is a preserved historical toolchain, not a current support claim. If inspected, use an isolated local environment only and do not connect it to production credentials, real user data, or a public network.
 
 ```bash
-git clone https://github.com/yourusername/catching-app.git
+git clone https://github.com/okturan/catching-app.git
 cd catching-app
-```
-
-2. **Install dependencies:***
-
-Ensure you have Ruby and Rails installed. Then run:
-
-```bash
 bundle install
 yarn install
+bin/rails db:setup
+bin/rails server
 ```
 
-3. **Set up the database:**
+The seeded accounts and passwords are fictional local sample data, not production credentials.
 
-Create and migrate the database:
+## Security boundary
+
+The current source limits event viewing to hosts and invitees, final scheduling to the host, and availability submission to invited guests. Account and event deletion also clean dependent invitations and time slots. Run the dependency-free source contract without installing the legacy Rails stack:
 
 ```bash
-rails db:create
-rails db:migrate
+ruby script/verify_archive_contract.rb
 ```
 
-4. **Run the application:**
+This static contract does not make the historical dependencies safe. The repository should stay unpinned and undeployed until the owner chooses either GitHub archival or a supported Ruby/Rails modernization with real model, request, and system tests plus zero critical/high dependency alerts.
 
-Start the Rails server:
+## Origin
 
-```bash
-rails server
-```
-You can now access the application at http://localhost:3000.
-
-## Usage
-
-Sign up for a new account or log in with an existing account.
-Navigate to the dashboard to create new events or view your existing events.
-Invite friends to your events and define available time slots for meetings.
+Created during the [Le Wagon coding bootcamp](https://www.lewagon.com).

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,7 @@
 class EventsController < ApplicationController
+  before_action :set_accessible_event, only: [ :show ]
+  before_action :set_owned_event, only: [ :update ]
+
   def create
     # Create new event with only event_params
     @event = Event.new(event_params)
@@ -34,7 +37,6 @@ class EventsController < ApplicationController
   def show
     # Seperate time slots by user
     # @time_slots sort by user_id
-    @event = Event.find(params[:id])
     @host = @event.user
     @host_time_slots = @event.time_slots.where(user: @host)
 
@@ -49,7 +51,6 @@ class EventsController < ApplicationController
   end
 
   def update
-    @event = Event.find(params[:id])
     @final_time_slots = time_slot_array_params[:time_slot_array]
 
     @final_time_slot_array = @final_time_slots.split(',')
@@ -71,6 +72,16 @@ class EventsController < ApplicationController
 
   def time_slot_array_params
     params.require(:time_slots).permit(:time_slot_array)
+  end
+
+  def set_accessible_event
+    hosted = Event.where(id: current_user.events.select(:id))
+    invited = Event.where(id: current_user.invited_events.select(:id))
+    @event = hosted.or(invited).find(params[:id])
+  end
+
+  def set_owned_event
+    @event = current_user.events.find(params[:id])
   end
 
   # def user_info_params

--- a/app/controllers/time_slots_controller.rb
+++ b/app/controllers/time_slots_controller.rb
@@ -1,7 +1,7 @@
 class TimeSlotsController < ApplicationController
   def create
     @time_slot_array = my_params[:time_slot_array]
-    @event = Event.find(my_params[:event_id])
+    @event = current_user.invited_events.find(my_params[:event_id])
     @time_slots = @time_slot_array.split(',')
     @time_slots.each do |slot|
       time_slot = TimeSlot.new(start_time: slot, user: current_user, event: @event)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,8 @@
 class Event < ApplicationRecord
   belongs_to :user
-  has_many :time_slots
-  has_many :user_events
+  has_many :time_slots, dependent: :destroy
+  has_many :user_events, dependent: :destroy
+  has_many :activities, dependent: :destroy
   has_many :invited_users, through: :user_events, source: :user
   validates :name, :description, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :events
-  has_many :time_slots
-  has_many :user_events
+  has_many :events, dependent: :destroy
+  has_many :time_slots, dependent: :destroy
+  has_many :user_events, dependent: :destroy
   has_many :invited_events, through: :user_events, source: :event
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  resources :events, only: [ :index, :show, :new, :create, :edit, :update ]
+  resources :events, only: [ :index, :show, :new, :create, :update ]
   resources :time_slots, only: [ :new, :create ]
   resource :dashboard, only: :show
 end

--- a/script/verify_archive_contract.rb
+++ b/script/verify_archive_contract.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+def assert(condition, message)
+  raise message unless condition
+end
+
+root = File.expand_path('..', __dir__)
+events_controller = File.read(File.join(root, 'app/controllers/events_controller.rb'))
+time_slots_controller = File.read(File.join(root, 'app/controllers/time_slots_controller.rb'))
+user = File.read(File.join(root, 'app/models/user.rb'))
+event = File.read(File.join(root, 'app/models/event.rb'))
+routes = File.read(File.join(root, 'config/routes.rb'))
+readme = File.read(File.join(root, 'README.md'))
+
+assert(events_controller.include?('before_action :set_accessible_event, only: [ :show ]'), 'Event show must use an access-scoped lookup')
+assert(events_controller.include?('before_action :set_owned_event, only: [ :update ]'), 'Event update must use an owner-scoped lookup')
+assert(events_controller.include?('@event = hosted.or(invited).find(params[:id])'), 'Event show must be limited to hosts and invitees')
+assert(events_controller.include?('@event = current_user.events.find(params[:id])'), 'Final scheduling must be limited to the host')
+assert(time_slots_controller.include?('@event = current_user.invited_events.find(my_params[:event_id])'), 'Availability submission must be limited to invited users')
+
+%w[events time_slots user_events].each do |association|
+  assert(user.include?("has_many :#{association}, dependent: :destroy"), "User #{association} must be cleaned on account deletion")
+end
+%w[time_slots user_events activities].each do |association|
+  assert(event.include?("has_many :#{association}, dependent: :destroy"), "Event #{association} must be cleaned on event deletion")
+end
+
+assert(!routes.include?(':edit, :update'), 'The unimplemented event edit route must remain absent')
+assert(readme.include?('must not be exposed or deployed'), 'README must retain the legacy dependency warning')
+assert(readme.include?('three-person Le Wagon project'), 'README must retain the collaboration boundary')
+
+puts 'Archive authorization contract passed'


### PR DESCRIPTION
## Summary
- replace the generic README with the actual scheduling flow, three-person attribution, and legacy-runtime boundary
- limit event viewing to hosts and invitees
- limit final scheduling to the event host
- limit availability submission to invited users
- clean event/invitation/time-slot dependents and remove the unimplemented edit route
- add a dependency-free archive authorization contract

## Security boundary
GitHub currently reports 241 open dependency alerts: 19 critical, 91 high, 88 moderate, and 43 low. This PR does not claim the Ruby 2.7/Rails 6 application is safe to expose or deploy.

## Attribution
GitHub attributes 47 of the newest 100 commits and 11 merged PRs to Okan; the README credits all three collaborators and links Okan-authored merged PRs.

## Verification
- `ruby script/verify_archive_contract.rb`
- Ruby syntax check across 70 tracked Ruby files
- current Dependabot severity inventory
- `git diff --check`